### PR TITLE
tplink-safeloader: add Archer C59, C60 support (CA)

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1037,6 +1037,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:Archer C59,product_ver:1.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:55530000}\r\n",
@@ -1076,6 +1077,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C59,product_ver:2.0.0,special_id:00000000}\r\n"
+			"{product_name:Archer C59,product_ver:2.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C59,product_ver:2.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C59,product_ver:2.0.0,special_id:55530000}\r\n",
 		.part_trail = 0x00,
@@ -1302,6 +1304,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C60,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:Archer C60,product_ver:1.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C60,product_ver:1.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C60,product_ver:1.0.0,special_id:55530000}\r\n",
 		.part_trail = 0x00,
@@ -1336,6 +1339,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C60,product_ver:2.0.0,special_id:42520000}\r\n"
+			"{product_name:Archer C60,product_ver:2.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C60,product_ver:2.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C60,product_ver:2.0.0,special_id:55530000}\r\n",
 		.part_trail = 0x00,
@@ -1372,6 +1376,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C60,product_ver:3.0.0,special_id:42520000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C60,product_ver:3.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C60,product_ver:3.0.0,special_id:55530000}\r\n",
 		.part_trail = 0x00,


### PR DESCRIPTION
Regional versions of the Archer C59 and C60 are supported with the right firmware ID.

C59 see: 
https://forum.openwrt.org/t/support-for-tp-link-archer-c59-v1-ca/140839
I also tested the change on a CA C59V1 that made its way over to the US.

C60 see: 
https://forum.openwrt.org/t/adding-support-for-canadian-tp-link-archer-c60-v2-0/75273

