### PR TITLE
firmware-utils: fix use of NULL string progname

### DIFF
--- a/src/mkzcfw.c
+++ b/src/mkzcfw.c
@@ -356,6 +356,8 @@ int main(int argc, char *argv[])
 {
 	int ret = EXIT_FAILURE;
 
+	progname = basename(argv[0]);
+
 	while ( 1 ) {
 		int c;
 


### PR DESCRIPTION
The compiler complains about several lines which use `progname`, but that char pointer was NULL.

Fixes: 16cff6c7ca36 ("firmware-utils: fix unused variable warnings")