### PR TITLE
firmware-utils: Add support for TP-Link Archer C59 v1(CA)

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1135,6 +1135,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:Archer C59,product_ver:1.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C59,product_ver:1.0.0,special_id:55530000}\r\n",


### PR DESCRIPTION
Add special_id for TP-Link Archer C59 v1 canadian version