### PR TITLE
tplink-safeloader: add support_list entry for Archer AX23 AX1800 v1.20

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -979,7 +979,7 @@ static struct device_info boards[] = {
 			"SupportList:\n"
 			"{product_name:Archer AX23,product_ver:1.0,special_id:45550000}\n"
 			"{product_name:Archer AX23,product_ver:1.20,special_id:45550000}\n"
-			"{product_name:Archer AX1800 ,product_ver:1.20,special_id:45550000}\n"
+			"{product_name:Archer AX1800,product_ver:1.20,special_id:45550000}\n"
 			"{product_name:Archer AX23,product_ver:1.0,special_id:4A500000}\n"
 			"{product_name:Archer AX23,product_ver:1.20,special_id:4A500000}\n"
 			"{product_name:Archer AX23,product_ver:1.0,special_id:4B520000}\n"

--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -979,6 +979,7 @@ static struct device_info boards[] = {
 			"SupportList:\n"
 			"{product_name:Archer AX23,product_ver:1.0,special_id:45550000}\n"
 			"{product_name:Archer AX23,product_ver:1.20,special_id:45550000}\n"
+			"{product_name:Archer AX1800 ,product_ver:1.20,special_id:45550000}\n"
 			"{product_name:Archer AX23,product_ver:1.0,special_id:4A500000}\n"
 			"{product_name:Archer AX23,product_ver:1.20,special_id:4A500000}\n"
 			"{product_name:Archer AX23,product_ver:1.0,special_id:4B520000}\n"


### PR DESCRIPTION
tplink-safeloader: add support_list entry for Archer AX23 AX1800 v1.20 special_id:45550000


https://forum.openwrt.org/t/add-support-for-tp-link-ax23-v1/130746/79