### PR TITLE
Adding support for TP-Link Archer A6 v3.2 (EU,RU)

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1330,7 +1330,9 @@ static struct device_info boards[] = {
 			"{product_name:Archer A6,product_ver:3.0.0,special_id:43410000}\n"
 			"{product_name:Archer A6,product_ver:3.0.0,special_id:55530000}\n"
 			"{product_name:Archer A6,product_ver:3.0.0,special_id:54570000}\n"
-			"{product_name:Archer A6,product_ver:3.0.0,special_id:4A500000}\n",
+			"{product_name:Archer A6,product_ver:3.0.0,special_id:4A500000}\n"
+			"{product_name:Archer A6,product_ver:3.20,special_id:45550000}\n"
+			"{product_name:Archer A6,product_ver:3.20,special_id:52550000}\n",
 		.part_trail = 0x00,
 		.soft_ver = SOFT_VER_TEXT("soft_ver:1.0.5\n"),
 


### PR DESCRIPTION
This commit adds support for TP-Link Archer A6 v3.2 (EU,RU). The hardware is identical to the other regions (v3), so it was sufficient to update the safeloader. Everything works as expected so far.