### PR TITLE
tplink-safeloader: Add support for TP-Link Deco M5

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1742,6 +1742,87 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the Deco M5 */
+	{
+		.id = "DECO-M5",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:55530000}\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:45550000}\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:43410000}\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:4A500000}\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:41550000}\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:4B520000}\n"
+			"{product_name:M5,product_ver:1.0.0,special_id:49440000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:55530000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:45550000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:43410000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:4A500000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:41550000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:4B520000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:49440000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:53570000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:42340000}\n"
+			"{product_name:M5,product_ver:3.0.0,special_id:54570000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:55530000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:45550000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:43410000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:4A500000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:41550000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:4B520000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:49440000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:53570000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:42340000}\n"
+			"{product_name:M5,product_ver:3.2.0,special_id:54570000}\n",
+		.part_trail = 0x00,
+		.soft_ver = SOFT_VER_DEFAULT,
+
+		.partitions = {
+			{"SBL1", 0x00000, 0x30000},
+			{"boot-config_0", 0x30000, 0x10000},
+			{"MIBIB", 0x40000, 0x10000},
+			{"boot-config_1", 0x50000, 0x10000},
+			{"QSEE", 0x60000, 0x60000},
+			{"CDT", 0xc0000, 0x10000},
+			{"DDRPARAMS", 0xd0000, 0x10000},
+			{"uboot-env", 0xe0000, 0x10000},
+			{"fs-uboot@0", 0xf0000, 0x80000},
+			{"radio", 0x170000, 0x0fff0},
+			{"bluetooth-XTAL", 0x17fff0, 0x00010},
+			{"default-mac", 0x180000, 0x01000},
+			{"device-id", 0x182000, 0x01000},
+			{"product-info", 0x183000, 0x05000},
+			{"support-list", 0x190000, 0x10000},
+			{"user-config", 0x200000, 0x10000},
+			{"device-config", 0x210000, 0x10000},
+			{"group-info", 0x220000, 0x10000},
+			{"partition-table@0", 0x230000, 0x02000},
+			{"os-image@0", 0x240000, 0x300000},
+			{"file-system@0", 0x540000, 0x790000},
+			{"soft-version@0", 0xcd0000, 0x10000},
+			{"profile@0", 0xce0000, 0x10000},
+			{"default-config@0", 0xcf0000, 0x10000},
+			{"partition-table@1", 0xd00000, 0x02000},
+			{"fs-uboot@1", 0xd10000, 0x80000},
+			{"os-image@1", 0xd90000, 0x400000},
+			{"file-system@1", 0x1190000, 0xc40000},
+			{"soft-version@1", 0x1dd0000, 0x10000},
+			{"profile@1", 0x1de0000, 0x10000},
+			{"default-config@1", 0x1df0000, 0x10000},
+			{"tm-sig", 0x1e00000, 0x200000},
+			{NULL, 0, 0}
+		},
+
+		.partition_names.partition_table = "partition-table@1",
+		.partition_names.soft_ver = "soft-version@1",
+		.partition_names.os_image = "os-image@1",
+		.partition_names.file_system = "file-system@1",
+
+		.first_sysupgrade_partition = "os-image@1",
+		.last_sysupgrade_partition = "file-system@1"
+	},
+
 	/** Firmware layout for the Deco S4 v2 */
 	{
 		.id     = "DECO-S4-V2",


### PR DESCRIPTION
Hello @oklona , I apologize for taking your changes and putting them under my name, but I would really like to move this project along. If you'd prefer that I don't do this please let me know. Otherwise, please review the changes I have made here. Again, I'm a little unsure about the block of code on L3684.

This change adds support for the TP-Link Deco-M5. I have checked IDs of the Deco-M5's sold here in Asia and they have the same ID numbers so it is not limited to EU models.