### PR TITLE
firmware-utils: fix typo in error message when no Open SSL library found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ IF(NOT ZLIB_FOUND)
 ENDIF()
 
 IF(NOT OPENSSL_FOUND)
-  MESSAGE(FATAL_ERROR "Unable to find OpenSSL librry.")
+  MESSAGE(FATAL_ERROR "Unable to find OpenSSL library.")
 ENDIF()
 
 ADD_DEFINITIONS(-Wall -Wno-unused-parameter)


### PR DESCRIPTION
Simply fix a typo in the error message: librry -> library