### PR TITLE
tplink-safeloader: add TL-WPA8635P v3 and TL-WPA8631P v4

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -2300,7 +2300,8 @@ static struct device_info boards[] = {
 			"SupportList:\n"
 			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:41550000}\n"
 			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:45550000}\n"
-			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:55530000}\n",
+			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:55530000}\n"
+			"{product_name:TL-WPA8635P,product_ver:3.0.0,special_id:46520000}\n",
 		.part_trail = 0x00,
 		.soft_ver = SOFT_VER_DEFAULT,
 
@@ -2314,8 +2315,8 @@ static struct device_info boards[] = {
 			{"default-region", 0x732300, 0x00010},
 			{"product-info", 0x732400, 0x00200},
 			{"extra-para", 0x732600, 0x00200},
-			{"soft-version", 0x732800, 0x00200},
-			{"support-list", 0x732a00, 0x00100},
+			{"soft-version", 0x732800, 0x00100},
+			{"support-list", 0x732900, 0x00200},
 			{"profile", 0x732b00, 0x00100},
 			{"default-config", 0x732c00, 0x00800},
 			{"plc-type", 0x733400, 0x00020},

--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -2301,6 +2301,7 @@ static struct device_info boards[] = {
 			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:41550000}\n"
 			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:45550000}\n"
 			"{product_name:TL-WPA8631P,product_ver:3.0.0,special_id:55530000}\n"
+			"{product_name:TL-WPA8631P,product_ver:4.0.0,special_id:45550000}\n"
 			"{product_name:TL-WPA8635P,product_ver:3.0.0,special_id:46520000}\n",
 		.part_trail = 0x00,
 		.soft_ver = SOFT_VER_DEFAULT,


### PR DESCRIPTION
TL-WPA8635P v3:
Inspecting the only available firmware wpa8635pv3_fr-up-ver3-0-0-P1-20210625-rel39993-APPLC.bin
shows the WPA8631Pv3 EU is also supported by that firmware and the
partition layout is identical to the currently supported WPA8631P v3
layout.

TL-WPA8631P v4:
The only available v4 firmware wpa8631pv4_eu-up-ver4-0-0-P1-20220510-rel56203-APPLC.bin
matches the v3 partition scheme.

In both cases, user testing confirms the existing WPA8631P v3 image
works on both devices.

Expand size of support-list partition into unused space in soft-version
(which is also supplied by tplink-safeloader) to fit the new entries.

Link: https://forum.openwrt.org/t/is-tp-link-tl-wpa8635p-v3-0-supported/137404/5
Link: https://forum.openwrt.org/t/support-for-tp-link-tl-wpa8631p-v4/162122

---

This can be added to openwrt repo branches `/main`, `/openwrt-22.03` and `/openwrt-23.05` branches. Thanks!