### PR TITLE
tplink-safeloader: add RU support-list entry for Archer C6U v1

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1371,7 +1371,8 @@ static struct device_info boards[] = {
 		.vendor = "",
 		.support_list =
 			"SupportList:\n"
-			"{product_name:Archer C6U,product_ver:1.0.0,special_id:45550000}\n",
+			"{product_name:Archer C6U,product_ver:1.0.0,special_id:45550000}\n"
+			"{product_name:Archer C6U,product_ver:1.0.0,special_id:52550000}\n",
 		.part_trail = 0x00,
 		.soft_ver = SOFT_VER_TEXT("soft_ver:1.0.2\n"),
 


### PR DESCRIPTION
Tested on actual hardware.