### PR TITLE
ptgen: don’t insert CHS gap head in MBR partition tables

### DIFF
--- a/src/ptgen.c
+++ b/src/ptgen.c
@@ -329,7 +329,7 @@ static inline void init_utf16(char *str, uint16_t *buf, unsigned bufsize)
 static int gen_ptable(uint32_t signature, int nr)
 {
 	struct pte pte[MBR_ENTRY_MAX];
-	unsigned long long start, len, sect = 0;
+	unsigned long long start, len, sect = kb_align ? 1 : sectors;
 	int i, fd, ret = -1;
 
 	memset(pte, 0, sizeof(struct pte) * MBR_ENTRY_MAX);
@@ -344,7 +344,7 @@ static int gen_ptable(uint32_t signature, int nr)
 		pte[i].active = ((i + 1) == active) ? 0x80 : 0;
 		pte[i].type = parts[i].type;
 
-		start = sect + sectors;
+		start = sect;
 		if (parts[i].start != 0) {
 			if (parts[i].start * 2 < start) {
 				fprintf(stderr, "Invalid start %lld for partition %d!\n",


### PR DESCRIPTION
When `ptgen` is aligning partitions on a specific kB boundary (`-l` option; OpenWrt uses [256kB for x86](https://github.com/openwrt/openwrt/blob/fd4ad6cae88d009e9560e4ee902bf20a5b42d36e/target/linux/x86/image/Makefile#L56), but other, larger values for some other architectures) and creating an MBR-type partition table (`-g` option absent), it was inserting an extra head’s worth of gap between partitions.

For example, in the x86 case, where OpenWrt builds an image using [`-h 16 -s 63`](https://github.com/openwrt/openwrt/blob/701d774f54aef2f9fe3c584700773dcb260dd03c/scripts/gen_image_generic.sh#L20), consisting of [16MB and 104MB partitions](https://github.com/openwrt/openwrt/blob/f02f6aaa8d4e1025ab4aa9f569123e57f689f4e5/config/Config-images.in#L290) by default, and 256kB alignment, `ptgen` produced:

```
Device Boot Start    End Sectors  Size Id Type
img1   *      512  33279   32768   16M 83 Linux
img2        33792 246783  212992  104M 83 Linux
```

Notice the 512-sector gap between the end of the first partition and the start of the second, despite the fact that sector 33280 (which immediately follows the first partition) would have been 256kB-aligned. This occurred because `ptgen` inserted a gap equal to one CHS head before 256kB-aligning the second partition. In this 63 sector/head geometry requested when OpenWrt builds an image, this gap results in 32,256 bytes of waste, which after kB-aligning, becomes 256kB of waste.

The expected layout, which is produced after this patch:

```
Device Boot Start    End Sectors  Size Id Type
img1   *      512  33279   32768   16M 83 Linux
img2        33280 246271  212992  104M 83 Linux
```

This gapless layout more closely resembles the layout when `ptgen` is used in GPT (`-g`) mode.

The 1-head gap between partitions in head-aligning mode (no `-l`) also appears to be unnecessary. The sole function of this gap seems to be to force the first partition to begin at the first sector of the second head rather than the first head, which would have resulted in a collision because the MBR partition table resides there. With this change, a different approach is taken, in which the first partition’s position is set more directly to the start of the first head, without affecting subsequent partitions. This eliminates the 32,256-byte gap between partitions in this mode. Note that when head-aligning, each partition’s size is padded as needed so as to consume an entire head, so any subsequent partition will still be head-aligned. In OpenWrt, only [gemini/dlink_dns-313](https://github.com/openwrt/openwrt/blob/9e02580d52ef6f2ee1eb38ae4e5977bb6002a552/target/linux/gemini/image/dns313_gen_hdd_img.sh#L25) and [layerscape sdcard](https://github.com/openwrt/openwrt/blob/7157c77c6d872375c3f6f42a49d1627c4c692472/target/linux/layerscape/image/gen_sdcard_head_img.sh#L21) images use `ptgen` to produce a non-kB-aligned MBR partition table, and it doesn’t appear that either will be negatively impacted by this change.