### PR TITLE
zytrx: add LTE5398-M904

### DIFF
--- a/src/zytrx.c
+++ b/src/zytrx.c
@@ -93,6 +93,7 @@ static struct board_t {
 } boards[] = {
 	{ "MT7621A", "NR7101", 0x07010001 },
 	{ "MT7621A", "LTE3301-PLUS", 0x03030001  },
+	{ "MT7621A", "LTE5398-M904", 0x05030908 },
 	{}
 };
 


### PR DESCRIPTION
Add header mapping for ZyXEL LTE5398-M904 to zytrx.

As part of adding support for ZyXEL LTE5398-M904 to OpenWRT it's necessary to update zytrx tool to support it as well.

Signed-off-by: Milan Krstic <milan.krstic@gmail.com>