### PR TITLE
russian archer a6 v2 string

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1219,6 +1219,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer A6,product_ver:2.0.0,special_id:45550000}\r\n"
+			"{product_name:Archer A6,product_ver:2.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:4A500000}\r\n",


### PR DESCRIPTION
```
# strings ArcherA6v2_ru-up-ver1-3-3-P1\[20230808-rel60959\].bin  | grep special
{product_name:Archer A6,product_ver:2.0.0,special_id:52550000}
```

https://forum.openwrt.org/t/tp-link-archer-a6-v2-eu-ru-support/60075/50


firmware url:

* https://www.tp-link.com/ru/support/download/archer-a6/#Firmware

@svanheule Suggested-by?