### PR TITLE
tplink-safeloader: add support for TP-Link RE205 V3

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -2762,6 +2762,49 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the RE205 v3 */
+	{
+		.id     = "RE205-V3",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:00000000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:45550000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:4A500000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:4B520000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:43410000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:41550000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:42520000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:55530000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:41520000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:52550000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:54570000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:45530000}\n"
+			"{product_name:RE205,product_ver:3.0.0,special_id:45470000}\n",
+		.part_trail = 0x00,
+		.soft_ver = SOFT_VER_TEXT("soft_ver:1.1.0\n"),
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x7a0000},
+			{"partition-table", 0x7c0000, 0x02000},
+			{"default-mac", 0x7c2000, 0x00020},
+			{"pin", 0x7c2100, 0x00020},
+			{"product-info", 0x7c3100, 0x01000},
+			{"soft-version", 0x7c4200, 0x01000},
+			{"support-list", 0x7c5200, 0x01000},
+			{"profile", 0x7c6200, 0x08000},
+			{"config-info", 0x7ce200, 0x00400},
+			{"user-config", 0x7d0000, 0x10000},
+			{"default-config", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the RE220 v2 */
 	{
 		.id     = "RE220-V2",


### PR DESCRIPTION
I have modified tplink-safeloader utility and added support to create factory images for TP-Link RE205 V3 devices.
I have tested the resulting factory image on my own hardware, I could successfully upgrade my device with an OpenWRT image.

Information like "special_id"s that was needed to modify the tool has been read out from an original firmware upgrade package.