### PR TITLE
tplink-safeloader: Archer C60 v3: add KR, TW, RU

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -1480,10 +1480,13 @@ static struct device_info boards[] = {
 		.vendor = "",
 		.support_list =
 			"SupportList:\r\n"
-			"{product_name:Archer C60,product_ver:3.0.0,special_id:42520000}\r\n"
-			"{product_name:Archer C60,product_ver:3.0.0,special_id:43410000}\r\n"
 			"{product_name:Archer C60,product_ver:3.0.0,special_id:45550000}\r\n"
-			"{product_name:Archer C60,product_ver:3.0.0,special_id:55530000}\r\n",
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:4B520000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:54570000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:42520000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:52550000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:55530000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:43410000}\r\n",
 		.part_trail = 0x00,
 		.soft_ver = SOFT_VER_TEXT("soft_ver:3.0.0\n"),
 


### PR DESCRIPTION
Added KR, TW, RU `special_id`s for Archer C60 v3's support list.

The stock TP-Link `.bin` firmware for this device contains the following

```
SupportList:
{product_name:Archer C60,product_ver:3.0.0,special_id:45550000}
{product_name:Archer C60,product_ver:3.0.0,special_id:4B520000}
{product_name:Archer C60,product_ver:3.0.0,special_id:54570000}
{product_name:Archer C60,product_ver:3.0.0,special_id:42520000}
{product_name:Archer C60,product_ver:3.0.0,special_id:52550000}
{product_name:Archer C60,product_ver:3.0.0,special_id:55530000}
{product_name:Archer C60,product_ver:3.0.0,special_id:43410000}
```

Hence, I'm updating the list to add the missing entries (all these devices use the same firmware).

- 4B520000 is KR
- 54570000 is TW
- 52550000 is RU

_(can be verified using Hex to ASCII tools)_