### PR TITLE
mktplinkfw2: Add 16Mmtk layout

### DIFF
--- a/src/mktplinkfw2.c
+++ b/src/mktplinkfw2.c
@@ -150,6 +150,12 @@ static struct flash_layout layouts[] = {
 		.kernel_ep	= 0x80000000,
 		.rootfs_ofs	= 0x140000,
 	}, {
+		.id		= "16Mmtk",
+		.fw_max_len	= 0xfa0000,
+		.kernel_la	= 0x80000000,
+		.kernel_ep	= 0x80000000,
+		.rootfs_ofs	= 0x140000,
+	}, {
 		.id		= "8MSUmtk", /* Split U-Boot OS */
 		.fw_max_len	= 0x770000,
 		.kernel_la	= 0x80000000,


### PR DESCRIPTION
This supports eg, TP-Link Archer MR200 v6

See new pending port: https://github.com/openwrt/openwrt/pull/15610

Signed-off-by: Damien Zammit <damien@zamaudio.com>