### PR TITLE
ptgen GPT improvements

### DIFF
--- a/src/ptgen.c
+++ b/src/ptgen.c
@@ -480,7 +480,8 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		printf("%" PRIu64 "\n", (sect - start) * DISK_SECTOR_SIZE);
 	}
 
-	if (parts[0].actual_start > GPT_FIRST_ENTRY_SECTOR + GPT_SIZE) {
+	if ((parts[i].start != 0) &&
+	    (parts[0].actual_start > GPT_FIRST_ENTRY_SECTOR + GPT_SIZE)) {
 		gpte[GPT_ENTRY_MAX - 1].start = cpu_to_le64(GPT_FIRST_ENTRY_SECTOR + GPT_SIZE);
 		gpte[GPT_ENTRY_MAX - 1].end = cpu_to_le64(parts[0].actual_start - 1);
 		gpte[GPT_ENTRY_MAX - 1].type = GUID_PARTITION_BIOS_BOOT;

--- a/src/ptgen.c
+++ b/src/ptgen.c
@@ -492,7 +492,7 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 
 	pte[0].type = 0xEE;
 	pte[0].start = cpu_to_le32(GPT_HEADER_SECTOR);
-	pte[0].length = cpu_to_le32(end - GPT_HEADER_SECTOR);
+	pte[0].length = cpu_to_le32(end + 1 - GPT_HEADER_SECTOR);
 	to_chs(GPT_HEADER_SECTOR, pte[0].chs_start);
 	to_chs(end, pte[0].chs_end);
 

--- a/src/ptgen.c
+++ b/src/ptgen.c
@@ -172,6 +172,7 @@ bool use_guid_partition_table = false;
 struct partinfo parts[GPT_ENTRY_MAX];
 char *filename = NULL;
 
+int gpt_full_image = false;
 int gpt_alternate = false;
 uint64_t gpt_first_entry_sector = GPT_FIRST_ENTRY_SECTOR;
 uint64_t gpt_last_usable_sector = 0;
@@ -424,6 +425,7 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 	uint64_t sect = GPT_SIZE + gpt_first_entry_sector;
 	int fd, ret = -1;
 	unsigned i, pmbr = 1;
+	char img_name[strlen(filename) + 20];
 
 	memset(pte, 0, sizeof(struct pte) * MBR_ENTRY_MAX);
 	memset(gpte, 0, GPT_ENTRY_SIZE * GPT_ENTRY_MAX);
@@ -518,8 +520,13 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		fprintf(stderr, "PartitionEntryLBA=%" PRIu64 ", FirstUsableLBA=%" PRIu64 ", LastUsableLBA=%" PRIu64 "\n",
 				gpt_first_entry_sector, gpt_first_entry_sector + GPT_SIZE, gpt_last_usable_sector);
 
-	if ((fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 0644)) < 0) {
-		fprintf(stderr, "Can't open output file '%s'\n",filename);
+	if (!gpt_full_image)
+		snprintf(img_name, sizeof(img_name), "%s.start", filename);
+	else
+		strcpy(img_name, filename);
+
+	if ((fd = open(img_name, O_WRONLY|O_CREAT|O_TRUNC, 0644)) < 0) {
+		fprintf(stderr, "Can't open output file '%s'\n",img_name);
 		return ret;
 	}
 
@@ -546,7 +553,24 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		goto fail;
 	}
 
-	lseek(fd, gpt_first_entry_sector * DISK_SECTOR_SIZE, SEEK_SET);
+	lseek(fd, 2 * DISK_SECTOR_SIZE - 1, SEEK_SET);
+	if (write(fd, "\x00", 1) != 1) {
+		fputs("write failed.\n", stderr);
+		goto fail;
+	}
+
+	if ((gpt_first_entry_sector == GPT_FIRST_ENTRY_SECTOR) || gpt_full_image) {
+		lseek(fd, gpt_first_entry_sector * DISK_SECTOR_SIZE, SEEK_SET);
+	} else {
+		close(fd);
+
+		snprintf(img_name, sizeof(img_name), "%s.entry", filename);
+		if ((fd = open(img_name, O_WRONLY|O_CREAT|O_TRUNC, 0644)) < 0) {
+			fprintf(stderr, "Can't open output file '%s'\n",img_name);
+			return ret;
+		}
+	}
+
 	if (write(fd, &gpte, GPT_ENTRY_SIZE * GPT_ENTRY_MAX) != GPT_ENTRY_SIZE * GPT_ENTRY_MAX) {
 		fputs("write failed.\n", stderr);
 		goto fail;
@@ -561,7 +585,19 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 	gpth.crc32 = 0;
 	gpth.crc32 = cpu_to_le32(gpt_crc32(&gpth, GPT_HEADER_SIZE));
 
-	lseek(fd, end * DISK_SECTOR_SIZE - GPT_ENTRY_SIZE * GPT_ENTRY_MAX, SEEK_SET);
+	if (gpt_full_image) {
+		lseek(fd, end * DISK_SECTOR_SIZE - GPT_ENTRY_SIZE * GPT_ENTRY_MAX, SEEK_SET);
+	} else {
+		close(fd);
+
+		end = GPT_SIZE;
+		snprintf(img_name, sizeof(img_name), "%s.end", filename);
+		if ((fd = open(img_name, O_WRONLY|O_CREAT|O_TRUNC, 0644)) < 0) {
+			fprintf(stderr, "Can't open output file '%s'\n",img_name);
+			return ret;
+		}
+	}
+
 	if (write(fd, &gpte, GPT_ENTRY_SIZE * GPT_ENTRY_MAX) != GPT_ENTRY_SIZE * GPT_ENTRY_MAX) {
 		fputs("write failed.\n", stderr);
 		goto fail;
@@ -588,7 +624,7 @@ fail:
 
 static void usage(char *prog)
 {
-	fprintf(stderr, "Usage: %s [-v] [-n] [-g] -h <heads> -s <sectors> -o <outputfile>\n"
+	fprintf(stderr, "Usage: %s [-v] [-n] [-b] [-g] -h <heads> -s <sectors> -o <outputfile>\n"
 			"          [-a <part number>] [-l <align kB>] [-G <guid>]\n"
 			"          [-e <gpt_entry_offset>] [-d <gpt_disk_size>]\n"
 			"          [[-t <type> | -T <GPT part type>] [-r] [-N <name>] -p <size>[@<start>]...] \n", prog);
@@ -630,7 +666,7 @@ int main (int argc, char **argv)
 	guid_t guid = GUID_INIT( signature, 0x2211, 0x4433, \
 			0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0x00);
 
-	while ((ch = getopt(argc, argv, "h:s:p:a:t:T:o:vnHN:gl:rS:G:e:d:")) != -1) {
+	while ((ch = getopt(argc, argv, "h:s:p:a:t:T:o:vnbHN:gl:rS:G:e:d:")) != -1) {
 		switch (ch) {
 		case 'o':
 			filename = optarg;
@@ -663,6 +699,7 @@ int main (int argc, char **argv)
 			break;
 		case 'd':
 			gpt_alternate = true;
+			gpt_full_image = true;
 			disk_size = (uint64_t)strtoull(optarg, NULL, 0);
 			if (disk_size % DISK_SECTOR_SIZE != 0) {
 				fprintf(stderr, "GPT disk size must be divided to %d\n",
@@ -675,6 +712,10 @@ int main (int argc, char **argv)
 				exit(EXIT_FAILURE);
 			}
 			gpt_last_usable_sector = disk_size / DISK_SECTOR_SIZE - GPT_SIZE - 2;
+			break;
+		case 'b':
+			gpt_alternate = true;
+			gpt_full_image = false;
 			break;
 		case 'h':
 			heads = (int)strtoul(optarg, NULL, 0);

--- a/src/ptgen.c
+++ b/src/ptgen.c
@@ -172,7 +172,9 @@ bool use_guid_partition_table = false;
 struct partinfo parts[GPT_ENTRY_MAX];
 char *filename = NULL;
 
+int gpt_alternate = false;
 uint64_t gpt_first_entry_sector = GPT_FIRST_ENTRY_SECTOR;
+uint64_t gpt_last_usable_sector = 0;
 
 /*
  * parse the size argument, which is either
@@ -443,6 +445,12 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		} else if (kb_align != 0) {
 			start = round_to_kb(start);
 		}
+		if ((gpt_last_usable_sector > 0) &&
+		    (start + parts[i].size * 2 > gpt_last_usable_sector + 1)) {
+				fprintf(stderr, "Partition %d ends after last usable sector %ld\n",
+					i, gpt_last_usable_sector);
+				return ret;
+		}
 		parts[i].actual_start = start;
 		gpte[i].start = cpu_to_le64(start);
 
@@ -490,7 +498,10 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		gpte[GPT_ENTRY_MAX - 1].guid.b[sizeof(guid_t) -1] += GPT_ENTRY_MAX;
 	}
 
-	end = sect + GPT_SIZE;
+	if (gpt_last_usable_sector == 0)
+		gpt_last_usable_sector = sect - 1;
+
+	end = gpt_last_usable_sector + GPT_SIZE + 1;
 
 	pte[0].type = 0xEE;
 	pte[0].start = cpu_to_le32(GPT_HEADER_SECTOR);
@@ -498,14 +509,14 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 	to_chs(GPT_HEADER_SECTOR, pte[0].chs_start);
 	to_chs(end, pte[0].chs_end);
 
-	gpth.last_usable = cpu_to_le64(end - GPT_SIZE - 1);
+	gpth.last_usable = cpu_to_le64(gpt_last_usable_sector);
 	gpth.alternate = cpu_to_le64(end);
 	gpth.entry_crc32 = cpu_to_le32(gpt_crc32(gpte, GPT_ENTRY_SIZE * GPT_ENTRY_MAX));
 	gpth.crc32 = cpu_to_le32(gpt_crc32((char *)&gpth, GPT_HEADER_SIZE));
 
 	if (verbose)
 		fprintf(stderr, "PartitionEntryLBA=%" PRIu64 ", FirstUsableLBA=%" PRIu64 ", LastUsableLBA=%" PRIu64 "\n",
-			gpt_first_entry_sector, gpt_first_entry_sector + GPT_SIZE, end - GPT_SIZE - 1);
+				gpt_first_entry_sector, gpt_first_entry_sector + GPT_SIZE, gpt_last_usable_sector);
 
 	if ((fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 0644)) < 0) {
 		fprintf(stderr, "Can't open output file '%s'\n",filename);
@@ -541,7 +552,9 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		goto fail;
 	}
 
-#ifdef WANT_ALTERNATE_PTABLE
+	if (!gpt_alternate)
+		goto end;
+
 	/* The alternate partition table (We omit it by default) */
 	swap(gpth.self, gpth.alternate);
 	gpth.first_entry = cpu_to_le64(end - GPT_ENTRY_SIZE * GPT_ENTRY_MAX / DISK_SECTOR_SIZE),
@@ -564,8 +577,9 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		fputs("write failed.\n", stderr);
 		goto fail;
 	}
-#endif
 
+
+end:
 	ret = 0;
 fail:
 	close(fd);
@@ -576,7 +590,7 @@ static void usage(char *prog)
 {
 	fprintf(stderr, "Usage: %s [-v] [-n] [-g] -h <heads> -s <sectors> -o <outputfile>\n"
 			"          [-a <part number>] [-l <align kB>] [-G <guid>]\n"
-			"          [-e <gpt_entry_offset>]\n"
+			"          [-e <gpt_entry_offset>] [-d <gpt_disk_size>]\n"
 			"          [[-t <type> | -T <GPT part type>] [-r] [-N <name>] -p <size>[@<start>]...] \n", prog);
 
 	exit(EXIT_FAILURE);
@@ -611,12 +625,12 @@ int main (int argc, char **argv)
 	int part = 0;
 	char *name = NULL;
 	unsigned short int hybrid = 0, required = 0;
-	uint64_t offs;
+	uint64_t offs, disk_size;
 	uint32_t signature = 0x5452574F; /* 'OWRT' */
 	guid_t guid = GUID_INIT( signature, 0x2211, 0x4433, \
 			0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0x00);
 
-	while ((ch = getopt(argc, argv, "h:s:p:a:t:T:o:vnHN:gl:rS:G:e:")) != -1) {
+	while ((ch = getopt(argc, argv, "h:s:p:a:t:T:o:vnHN:gl:rS:G:e:d:")) != -1) {
 		switch (ch) {
 		case 'o':
 			filename = optarg;
@@ -646,6 +660,21 @@ int main (int argc, char **argv)
 				exit(EXIT_FAILURE);
 			}
 			gpt_first_entry_sector = offs / DISK_SECTOR_SIZE;
+			break;
+		case 'd':
+			gpt_alternate = true;
+			disk_size = (uint64_t)strtoull(optarg, NULL, 0);
+			if (disk_size % DISK_SECTOR_SIZE != 0) {
+				fprintf(stderr, "GPT disk size must be divided to %d\n",
+				        DISK_SECTOR_SIZE);
+				exit(EXIT_FAILURE);
+			}
+			if (disk_size < DISK_SECTOR_SIZE * (2 * GPT_SIZE + 3)) {
+				fprintf(stderr, "GPT disk size must be larger than 0x%x\n",
+				        DISK_SECTOR_SIZE * (2 * GPT_SIZE + 3));
+				exit(EXIT_FAILURE);
+			}
+			gpt_last_usable_sector = disk_size / DISK_SECTOR_SIZE - GPT_SIZE - 2;
 			break;
 		case 'h':
 			heads = (int)strtoul(optarg, NULL, 0);

--- a/src/ptgen.c
+++ b/src/ptgen.c
@@ -172,6 +172,7 @@ bool use_guid_partition_table = false;
 struct partinfo parts[GPT_ENTRY_MAX];
 char *filename = NULL;
 
+uint64_t gpt_first_entry_sector = GPT_FIRST_ENTRY_SECTOR;
 
 /*
  * parse the size argument, which is either
@@ -410,15 +411,15 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		.revision = cpu_to_le32(GPT_REVISION),
 		.size = cpu_to_le32(GPT_HEADER_SIZE),
 		.self = cpu_to_le64(GPT_HEADER_SECTOR),
-		.first_usable = cpu_to_le64(GPT_FIRST_ENTRY_SECTOR + GPT_ENTRY_SIZE * GPT_ENTRY_MAX / DISK_SECTOR_SIZE),
-		.first_entry = cpu_to_le64(GPT_FIRST_ENTRY_SECTOR),
+		.first_usable = cpu_to_le64(gpt_first_entry_sector + GPT_SIZE),
+		.first_entry = cpu_to_le64(gpt_first_entry_sector),
 		.disk_guid = guid,
 		.entry_num = cpu_to_le32(GPT_ENTRY_MAX),
 		.entry_size = cpu_to_le32(GPT_ENTRY_SIZE),
 	};
 	struct gpte  gpte[GPT_ENTRY_MAX];
 	uint64_t start, end;
-	uint64_t sect = GPT_SIZE + GPT_FIRST_ENTRY_SECTOR;
+	uint64_t sect = GPT_SIZE + gpt_first_entry_sector;
 	int fd, ret = -1;
 	unsigned i, pmbr = 1;
 
@@ -481,8 +482,8 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 	}
 
 	if ((parts[i].start != 0) &&
-	    (parts[0].actual_start > GPT_FIRST_ENTRY_SECTOR + GPT_SIZE)) {
-		gpte[GPT_ENTRY_MAX - 1].start = cpu_to_le64(GPT_FIRST_ENTRY_SECTOR + GPT_SIZE);
+	    (parts[0].actual_start > gpt_first_entry_sector + GPT_SIZE)) {
+		gpte[GPT_ENTRY_MAX - 1].start = cpu_to_le64(gpt_first_entry_sector + GPT_SIZE);
 		gpte[GPT_ENTRY_MAX - 1].end = cpu_to_le64(parts[0].actual_start - 1);
 		gpte[GPT_ENTRY_MAX - 1].type = GUID_PARTITION_BIOS_BOOT;
 		gpte[GPT_ENTRY_MAX - 1].guid = guid;
@@ -501,6 +502,10 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 	gpth.alternate = cpu_to_le64(end);
 	gpth.entry_crc32 = cpu_to_le32(gpt_crc32(gpte, GPT_ENTRY_SIZE * GPT_ENTRY_MAX));
 	gpth.crc32 = cpu_to_le32(gpt_crc32((char *)&gpth, GPT_HEADER_SIZE));
+
+	if (verbose)
+		fprintf(stderr, "PartitionEntryLBA=%" PRIu64 ", FirstUsableLBA=%" PRIu64 ", LastUsableLBA=%" PRIu64 "\n",
+			gpt_first_entry_sector, gpt_first_entry_sector + GPT_SIZE, end - GPT_SIZE - 1);
 
 	if ((fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 0644)) < 0) {
 		fprintf(stderr, "Can't open output file '%s'\n",filename);
@@ -530,7 +535,7 @@ static int gen_gptable(uint32_t signature, guid_t guid, unsigned nr)
 		goto fail;
 	}
 
-	lseek(fd, GPT_FIRST_ENTRY_SECTOR * DISK_SECTOR_SIZE, SEEK_SET);
+	lseek(fd, gpt_first_entry_sector * DISK_SECTOR_SIZE, SEEK_SET);
 	if (write(fd, &gpte, GPT_ENTRY_SIZE * GPT_ENTRY_MAX) != GPT_ENTRY_SIZE * GPT_ENTRY_MAX) {
 		fputs("write failed.\n", stderr);
 		goto fail;
@@ -571,7 +576,9 @@ static void usage(char *prog)
 {
 	fprintf(stderr, "Usage: %s [-v] [-n] [-g] -h <heads> -s <sectors> -o <outputfile>\n"
 			"          [-a <part number>] [-l <align kB>] [-G <guid>]\n"
+			"          [-e <gpt_entry_offset>]\n"
 			"          [[-t <type> | -T <GPT part type>] [-r] [-N <name>] -p <size>[@<start>]...] \n", prog);
+
 	exit(EXIT_FAILURE);
 }
 
@@ -604,11 +611,12 @@ int main (int argc, char **argv)
 	int part = 0;
 	char *name = NULL;
 	unsigned short int hybrid = 0, required = 0;
+	uint64_t offs;
 	uint32_t signature = 0x5452574F; /* 'OWRT' */
 	guid_t guid = GUID_INIT( signature, 0x2211, 0x4433, \
 			0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0x00);
 
-	while ((ch = getopt(argc, argv, "h:s:p:a:t:T:o:vnHN:gl:rS:G:")) != -1) {
+	while ((ch = getopt(argc, argv, "h:s:p:a:t:T:o:vnHN:gl:rS:G:e:")) != -1) {
 		switch (ch) {
 		case 'o':
 			filename = optarg;
@@ -624,6 +632,20 @@ int main (int argc, char **argv)
 			break;
 		case 'H':
 			hybrid = 1;
+			break;
+		case 'e':
+			offs = (uint64_t)strtoull(optarg, NULL, 0);
+			if (offs % DISK_SECTOR_SIZE != 0) {
+				fprintf(stderr, "GPT First Entry offset must be %d aligned value\n",
+				        DISK_SECTOR_SIZE);
+				exit(EXIT_FAILURE);
+			}
+			if (offs < GPT_FIRST_ENTRY_SECTOR * DISK_SECTOR_SIZE) {
+				fprintf(stderr, "GPT First Entry offset must greater than 0x%x\n",
+				        GPT_FIRST_ENTRY_SECTOR * DISK_SECTOR_SIZE);
+				exit(EXIT_FAILURE);
+			}
+			gpt_first_entry_sector = offs / DISK_SECTOR_SIZE;
 			break;
 		case 'h':
 			heads = (int)strtoul(optarg, NULL, 0);


### PR DESCRIPTION
This patch series improves GPT support by ptgen utility.
The most focus is done on specific case where primary GPT entry table placed with a gap from GPT header.
The gap is used by a vendor for bootloader code.

Also one ptgen bug was fixed.

Mikhail Kshevetskiy (5):
* ptgen: fix protective MBR partition size
* ptgen: do not create stab partition to fill a gap if gap caused by alignment
* ptgen: allow non-default placement of gpt entry table
* ptgen: allow image generation for a specified disk size
* ptgen: create separate images for gpt data structure
