### PR TITLE
mktplinkfw2: Add 16MLmtk layout

### DIFF
--- a/src/mktplinkfw2.c
+++ b/src/mktplinkfw2.c
@@ -150,6 +150,12 @@ static struct flash_layout layouts[] = {
 		.kernel_ep	= 0x80000000,
 		.rootfs_ofs	= 0x140000,
 	}, {
+		.id		= "16MLmtk",
+		.fw_max_len	= 0xe90000,
+		.kernel_la	= 0x80000000,
+		.kernel_ep	= 0x80000000,
+		.rootfs_ofs	= 0x140000,
+	}, {
 		.id		= "16Mmtk",
 		.fw_max_len	= 0xfa0000,
 		.kernel_la	= 0x80000000,


### PR DESCRIPTION
Hello everyone,

I'm working on adding new device support and without this patch I won't be able to continue and submit patches to OpenWRT.
This layout is used by MERCUSYS MB130-4G which bootloader is based on TP-Link MR200/MR400 source code, but has bigger flash.

Thank you,
Sergey