### PR TITLE
iptime-crc32: add support for ipTIME AX3000SM

### DIFF
--- a/src/iptime-crc32.c
+++ b/src/iptime-crc32.c
@@ -57,6 +57,7 @@ struct board_info boards[] = {
 	{ .model = "ax3000m", .payload_offset = 0x38 },
 	{ .model = "ax3000q", .payload_offset = 0x38 },
 	{ .model = "ax8004m", .payload_offset = 0x38 },
+	{ .model = "ax3ksm", .payload_offset = 0x38 },
 	{ /* sentinel */ }
 };
 


### PR DESCRIPTION
Add support to create flashable factory image for ipTIME AX3000SM.