### PR TITLE
iptime-crc32: add support for ipTIME AX3000Q

### DIFF
--- a/src/iptime-crc32.c
+++ b/src/iptime-crc32.c
@@ -55,6 +55,7 @@ struct board_info boards[] = {
 	{ .model = "a6004mx", .payload_offset = 0x800 },
 	{ .model = "ax2004m", .payload_offset = 0x38 },
 	{ .model = "ax3000m", .payload_offset = 0x38 },
+	{ .model = "ax3000q", .payload_offset = 0x38 },
 	{ .model = "ax8004m", .payload_offset = 0x38 },
 	{ /* sentinel */ }
 };


### PR DESCRIPTION
Add support to create flashable factory image for ipTIME AX3000Q.

The pull request for adding support to ipTIME AX3000Q: [https://github.com/openwrt/openwrt/pull/19368](https://github.com/openwrt/openwrt/pull/19368)