### PR TITLE
iptime-crc32: Add device support for ipTIME AX6000M

### DIFF
--- a/src/iptime-crc32.c
+++ b/src/iptime-crc32.c
@@ -56,6 +56,7 @@ struct board_info boards[] = {
 	{ .model = "ax2004m", .payload_offset = 0x38 },
 	{ .model = "ax3000m", .payload_offset = 0x38 },
 	{ .model = "ax3000q", .payload_offset = 0x38 },
+	{ .model = "ax6000m", .payload_offset = 0x38 },
 	{ .model = "ax8004m", .payload_offset = 0x38 },
 	{ .model = "ax3ksm", .payload_offset = 0x38 },
 	{ /* sentinel */ }


### PR DESCRIPTION
Add support for ipTIME AX6000M model in iptime-crc32.

#### Small notes (skip if you don't want to read)

- I have not checked, but it seems like most of the ipTIME router models released are using `0x38` payload offset.
The specifications may be changed, but referring to other people's Pull Request, it seems that value `0x38` is maintained for the current devices.

- It seems like PR 44 and 45 is ahead of me. If there's any rebase needed feel free to mention or contact me. Thanks in advance.
