### PR TITLE
mkzynfw: add board definitions for Zyxel XS1930 switches

### DIFF
--- a/src/mkzynfw.c
+++ b/src/mkzynfw.c
@@ -118,6 +118,10 @@ int num_blocks = 0;
 #define AR71XX_FLASH_BASE	0xBFC00000
 #define AR71XX_CODE_START	0x81E00000
 
+#define RTL93XX_FLASH_BASE	0xB4000000
+#define RTL93XX_CODE_START	0x80220000
+#define RTL93XX_BOOTEXT_SIZE	0x10000
+
 #define BOARD(n, d, v, m, fb, fs, cs, fo) {		\
 	.name = (n), .desc=(d),				\
 	.vendor = (v), .model = (m),			\
@@ -146,6 +150,13 @@ int num_blocks = 0;
 	.bootext_size = 0x30000		\
 	}
 
+#define RTL93XXBOARD(n, d, m, fs, fo) {					\
+	.name = (n), .desc = (d),					\
+	.vendor = (ZYNOS_VENDOR_ID_ZYXEL), .model = (m),		\
+	.flash_base = (RTL93XX_FLASH_BASE), .flash_size = (fs)<<20,	\
+	.code_start = (RTL93XX_CODE_START), .romio_offs = (fo),		\
+	.bootext_size = (RTL93XX_BOOTEXT_SIZE)				\
+	}
 
 static struct board_info boards[] = {
 	/*
@@ -225,6 +236,15 @@ static struct board_info boards[] = {
 	 * Atheros ar71xx based boards
 	 */
 	AR71XXBOARD1("NBG-460N", "ZyXEL NBG-460N", ZYNOS_MODEL_NBG_460N, 4),
+
+	/*
+	 * Realtek RTL93xx based boards
+	 */
+	RTL93XXBOARD("XS1930-10", "Zyxel XS1930-10", MID(29698), 32, 0x280000),		/* ABQE */
+	RTL93XXBOARD("XS1930-12F", "Zyxel XS1930-12F", MID(33026), 32, 0x280000),	/* ABZV */
+	RTL93XXBOARD("XS1930-12HP", "Zyxel XS1930-12HP", MID(29954), 32, 0x280000),	/* ABQF */
+	RTL93XXBOARD("XMG1930-30", "Zyxel XMG1930-30", MID(33794), 32, 0x280000),	/* ACAR */
+	RTL93XXBOARD("XMG1930-30HP", "Zyxel XMG1930-30HP", MID(34050), 32, 0x280000),	/* ACAS */
 
 	{.name = NULL}
 };


### PR DESCRIPTION
Add board definitions for Realtek RTL93XX-based switches from Zyxel from product lines XS1930 and XMG1930. They share a common vendor-firmware image and thus can be added as similar boards here. Though the flash size and thus the romio_ofs are the same for all boards, they are not hardcoded in the macro since both may be different for further devices.