### PR TITLE
tplink-safeloader: add support for Festa F52 outdoor v1

### DIFF
--- a/src/tplink-safeloader.c
+++ b/src/tplink-safeloader.c
@@ -2091,6 +2091,35 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the F52-Outdoor v1 */
+	{
+		.id     = "F52-V1",
+		.support_list =
+			"SupportList:\r\n"
+			"Festa F52-Outdoor(TP-Link|UN|AC1200-D):1.0\r\n",
+		.part_trail = PART_TRAIL_NONE,
+		.soft_ver = SOFT_VER_DEFAULT,
+		.soft_ver_compat_level = 2,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x01000},
+			{"support-list", 0x31000, 0x00100},
+			{"product-info", 0x31100, 0x00400},
+			{"soft-version", 0x32000, 0x00100},
+			{"firmware", 0x40000, 0xd80000},
+			{"user-config", 0xdc0000, 0x30000},
+			{"mutil-log", 0xf30000, 0x80000},
+			{"oops", 0xfb0000, 0x40000},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the EAP225-Wall v2 */
 	{
 		.id     = "EAP225-WALL-V2",


### PR DESCRIPTION
This PR adds support to the tplink-safeloader for the tplink festa f52 outdoor (v1). Its basically the same as the tplink eap225-outdor (v3).

This is necessary to support the f52 outdoor in openwrt.