### PR TITLE
zyimage: make output byte order explicit

### DIFF
--- a/src/zyimage.c
+++ b/src/zyimage.c
@@ -8,6 +8,11 @@
 #include <sys/types.h>
 #include <string.h>
 #include <unistd.h>
+#if defined(__linux__)
+#include <endian.h>
+#else
+#include <sys/endian.h>
+#endif
 
 #define szbuf 32768
 
@@ -132,7 +137,15 @@ int main(int argc, char *argv[]) {
     }
 
     fseek(f, 0, SEEK_SET);
-    sign.crc32 = chksum_crc32(f);
+    /*
+     * On-disk fields are little-endian, matching every existing
+     * ZYIMAGE_ID value in the OpenWrt tree (unlike the vendor tool,
+     * which writes device_id big-endian). E.g. ZYIMAGE_ID 0x804410 and
+     * the vendor's CONFIG_TARGET_DEVICE_ID="0x10448000" are the same
+     * four bytes in opposite order.
+     */
+    sign.device_id = htole32(sign.device_id);
+    sign.crc32 = htole32(chksum_crc32(f));
     fwrite(&sign, sizeof(sign), 1, f);
     fclose(f);
 


### PR DESCRIPTION
zyimage writes device_id and crc32 into the signature header in native host byte order — there is no htobe32/htole32 call anywhere in the tool, so the output is only correct on little-endian build hosts. This makes the existing little-endian behavior explicit with htole32() on both fields and documents the byte layout, so the relationship between OpenWrt's ZYIMAGE_ID values and the vendor's device-id constants is discoverable from the source.

I used htole32 rather than htobe32 to match the actual on-disk format: OpenWrt's ZYIMAGE_ID definitions were chosen assuming this little-endian encoding, and switching to big-endian would silently change the on-disk device id for every device that currently uses zyimage.

Testing: built with CMake on Linux and with a plain compiler on macOS. Verified the change is output-neutral on little-endian hosts by building the tool before and after the change and comparing signed output byte-for-byte across several device ids and file sizes.
