### PR TITLE
mksenaofw: warn instead of erroring on plain type-0 images

### DIFF
--- a/src/mksenaofw.c
+++ b/src/mksenaofw.c
@@ -523,10 +523,8 @@ int main(int argc, char *argv[])
 	}
 
 	if ((header.firmware_type == 0) &&
-	    (cw_header.datecode == DATECODE_NONE)) {
-		fprintf(stderr, "Firmware type must be non-zero for non-capwap images\n");
-		usage(progname, EXIT_FAILURE);
-	}
+	    (cw_header.datecode == DATECODE_NONE))
+		fprintf(stderr, "Warning: firmware type 0 with no capwap header; building a plain image\n");
 
 	if (header.vendor_id == 0 || header.product_id == 0) {
 		fprintf(stderr,	"Vendor ID and Product ID must be defined and non-zero\n");


### PR DESCRIPTION
firmware_type 0 ("combo") is currently a fatal error unless a capwap header is supplied. Some rebranded Senao devices ship a plain type-0 header with no capwap section; notably the Netgear WAX214 and WAX218 (vendor_id 0x231), whose stock web-UI updater accepts the bare 0x60 img_header + magic-XOR'd payload.

This downgrades that case to a non-fatal warning. Capwap encodes always set a datecode (`-c`), so it only affects a type-0 encode with no capwap arguments; `encode_image()` already omits the capwap section and computes the checksum over the 0x60 header alone when no capwap header is supplied, so a plain image is produced correctly.

Used by a new qualcommax/ipq60xx web-UI factory image for the WAX214 (openwrt/openwrt#24895).

Testing: compiles; `mksenaofw -r 0x231 -p 0x11d -t 0 -v 9.9.9.9 -e fit -o out` prints the warning, exits 0, and reproduces a genuine stock WAX214 header field-for-field with a byte-identical XOR payload (only the uninitialised `pad` and the non-gated `chksum` differ).

https://forum.openwrt.org/t/wax214-v1-no-serial-openwrt-install-via-the-stock-web-ui-working/252965